### PR TITLE
Fix issue 11

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -918,6 +918,10 @@ def test_lookup(instruction, cycles, parser_table):
     assert entry["cycles"] == cycles, "Failed: {} expected '{}' != found '{}'".format(instruction, cycles, entry["cycles"])
 
 
+##########################################################################
+# _extract_mnemonic                                                      #
+##########################################################################
+
 @pytest.mark.parametrize("line,operator", (
     ("foo: LD A, 1 ; load accumulator", "LD"),
     ("foo: CALL 0xABCD", "CALL"),
@@ -935,3 +939,22 @@ def test_extract_mnemonic(line, operator):
 
 def test_extract_mnemonic_normalizes_operator():
     assert Parser._extract_mnemonic("call 0xabcd") == "CALL"
+
+
+##########################################################################
+# _remove_label                                                          #
+##########################################################################
+
+@pytest.mark.parametrize("line,expected", (
+    ("foo: ld A, 1 ; load accumulator", "ld A, 1 ; load accumulator"),
+    ("foo: CALL 0xABCD", "CALL 0xABCD"),
+    ("foo: EI", "EI"),
+    ("LD A, 1 ; load accumulator", "LD A, 1 ; load accumulator"),
+    ("call 0xABCE", "call 0xABCE"),
+    ("EI", "EI"),
+    ("foo: ; some label", None),
+    ("foo:", None),
+    ("; some comment", None),
+))
+def test_remove_label(line, expected):
+    assert Parser._remove_label(line) == expected

--- a/tests/test_z80count.py
+++ b/tests/test_z80count.py
@@ -9,6 +9,8 @@ from z80count.z80count import z80count
 @pytest.mark.parametrize("line,expected", (
     ("PLY_InterruptionOn: call PLY_Init",
      "PLY_InterruptionOn: call PLY_Init ; [17]\n"),
+    ("$PLY_Interruption.On: call PLY_Init",
+     "$PLY_Interruption.On: call PLY_Init ; [17]\n"),
     ("PLY_ReplayFrequency:\tld de,0",
      "PLY_ReplayFrequency:\tld de,0 ; [10]\n"),
 

--- a/tests/test_z80count.py
+++ b/tests/test_z80count.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from z80count.z80count import Parser
+from z80count.z80count import z80count
+
+
+@pytest.mark.parametrize("line,expected", (
+    ("PLY_InterruptionOn: call PLY_Init",
+     "PLY_InterruptionOn: call PLY_Init ; [17]\n"),
+    ("PLY_ReplayFrequency:\tld de,0",
+     "PLY_ReplayFrequency:\tld de,0 ; [10]\n"),
+
+))
+def test_issue_11(line, expected):
+    parser = Parser()
+    output, _ = z80count(line, parser, total=0, subt=False,
+                         no_update=True, column=1, use_tabs=False,
+                         tab_width=4, debug=False)
+    assert output == expected

--- a/z80count/z80count.py
+++ b/z80count/z80count.py
@@ -186,7 +186,7 @@ class Parser(object):
     """Simple parser based on a table of regexes."""
 
     # [label:] OPERATOR [OPERANDS] [; comment]
-    _LINE_RE = re.compile(r"^([\w]+:)?\s*(?P<operator>\w+)(?P<rest>\s+.*)?$")
+    _LINE_RE = re.compile(r"^([$.\w]+:)?\s*(?P<operator>\w+)(?P<rest>\s+.*)?$")
 
     def __init__(self):
         self._table = self._load_table()

--- a/z80count/z80count.py
+++ b/z80count/z80count.py
@@ -186,13 +186,14 @@ class Parser(object):
     """Simple parser based on a table of regexes."""
 
     # [label:] OPERATOR [OPERANDS] [; comment]
-    _LINE_RE = re.compile(r"^([\w]+:)?\s*(?P<operator>\w+)(\s+.*)?$")
+    _LINE_RE = re.compile(r"^([\w]+:)?\s*(?P<operator>\w+)(?P<rest>\s+.*)?$")
 
     def __init__(self):
         self._table = self._load_table()
 
     def lookup(self, line):
         mnemo = self._extract_mnemonic(line)
+        line = self._remove_label(line)
         if mnemo is None or mnemo not in self._table:
             return None
         for entry in self._table[mnemo]:
@@ -224,6 +225,14 @@ class Parser(object):
         match = cls._LINE_RE.match(line)
         if match:
             return match.group("operator").upper()
+        return None
+
+    @classmethod
+    def _remove_label(cls, line):
+        match = cls._LINE_RE.match(line)
+        if match:
+            rest = match.group("rest") or ""
+            return match.group("operator") + rest
         return None
 
     @staticmethod


### PR DESCRIPTION
See issue #11.

The problem is caused because the parser does not handle correctly the lines with both labels and operations. This PR solves the problem amb fixes the regex used to parse labels in order to make it compatible with SDCC.

I think this time I've done it right.